### PR TITLE
Update weekly sync cron job, add quotes

### DIFF
--- a/.github/workflows/weekly-team-sync.yml
+++ b/.github/workflows/weekly-team-sync.yml
@@ -5,7 +5,7 @@ name: Weekly Team Sync
 on:
   schedule:
   # Every day at noon
-  - cron: 10 3 * * TUE 
+  - cron: '25 3 * * TUE'
 
 jobs:
   create_issue:


### PR DESCRIPTION
Cron job requires quotes since it uses '*'. 
Action wasn't running, let's see if it works now.